### PR TITLE
Reverting fit test model()

### DIFF
--- a/R/enrichment_analysis.R
+++ b/R/enrichment_analysis.R
@@ -25,7 +25,7 @@ enrich_analysis <- function(counts_file, sample_table_file, db, ontology = NULL,
   dge <- digital_gene_expression(data)
 
   # Linear regression using generalized linear model
-  deg <- fit_test_model(dge[[2]], dge[[1]])
+  deg <- fit_test_model(data)
 
   # Returns a data frame with DEGS meeting the inputed log fold change and
   # adjusted p-values (FDR) conditions.

--- a/R/fit_test_model.R
+++ b/R/fit_test_model.R
@@ -5,8 +5,7 @@
 #' linear model to test for differentially expressed genes using functions from
 #' the edgeR and limma package
 #'
-#' @param dge_list DGEList object
-#' @param design_matrix numeric design matrix
+#' @param digital_deg_list list containing a design matrix and a DGElist object.
 #'
 #' @import edgeR
 #' @import limma
@@ -16,7 +15,10 @@
 #' @export
 #'
 
-fit_test_model <- function(dge_list, design_matrix) {
+fit_test_model <- function(digital_deg_list) {
+
+  design_matrix <- digital_deg_list[[1]]
+  dge_list <- digital_deg_list[[2]]
 
   # Estimate Common, Trended and Tagwise dispersions and adds to dge_list
   dge_list <- estimateDisp(dge_list, design_matrix)

--- a/man/fit_test_model.Rd
+++ b/man/fit_test_model.Rd
@@ -4,12 +4,10 @@
 \alias{fit_test_model}
 \title{Linear regression using generalized linear model}
 \usage{
-fit_test_model(dge_list, design_matrix)
+fit_test_model(digital_deg_list)
 }
 \arguments{
-\item{dge_list}{DGEList object}
-
-\item{design_matrix}{numeric design matrix}
+\item{digital_deg_list}{list containing a design matrix and a DGElist object.}
 }
 \value{
 Digital Gene Expression Likelihood Ratio Test data and results


### PR DESCRIPTION
For smoother experience, reverting my suggestion of having fit_test_model() take two arguments.
We will follow through with the original idea that Luan had and have it take the digital_expression list.